### PR TITLE
Logger

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,4 @@
 .gitignore
+*.ftl
+*.config.js
+.eslintrc.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,1 +1,1 @@
-eslint.config.js
+module.exports = require('./eslint.config');

--- a/app/util/localization.js
+++ b/app/util/localization.js
@@ -1,6 +1,7 @@
 import { FluentBundle } from 'fluent';
 import { zip } from 'ramda';
 import enCA from '../../localization/en-CA.ftl';
+import logger from './logger';
 
 const bundle = fetch(enCA)
   .then((response) => response.text())
@@ -11,7 +12,7 @@ const bundle = fetch(enCA)
         REF: ([key], params) => {
           const message = bundle.getMessage(key);
           if (!message) {
-            console.error(`\`ref\` lookup failed. Unknown key ${key}`);
+            logger.error(`\`ref\` lookup failed. Unknown key ${key}`);
             return key;
           }
           return bundle.format(message, params);
@@ -20,7 +21,7 @@ const bundle = fetch(enCA)
     });
     const errors = bundle.addMessages(src);
     for (const error of errors) {
-      console.error(error);
+      logger.error(error);
     }
     return bundle;
   });
@@ -29,13 +30,13 @@ export default async function loc(key, params) {
   const b = await bundle;
   const message = b.getMessage(key);
   if (!message) {
-    console.error(`Unknown message ${key}`);
+    logger.error(`Unknown message ${key}`);
     return key;
   }
   const errors = [];
   const result = b.format(message, params, errors);
   for (const error of errors) {
-    console.error(error);
+    logger.error(error);
   }
   return result;
 }

--- a/app/util/logger.js
+++ b/app/util/logger.js
@@ -1,0 +1,46 @@
+/* eslint-disable no-console */
+// TODO: bind loglevel with env variables
+// I'm not yet sure about the way env variables
+// will be implemented in project
+
+// loglevel values:
+// 0 - silence
+// 1 - error
+// 2 - warn
+// 3 - info
+// 4 - log
+// 5 - trace
+
+const logLevel = 5;
+
+export default {
+  trace(...args) {
+    if (logLevel > 4) {
+      console.trace(...args);
+    }
+  },
+
+  log(...args) {
+    if (logLevel > 3) {
+      console.log(...args);
+    }
+  },
+
+  info(...args) {
+    if (logLevel > 2) {
+      console.info(...args);
+    }
+  },
+
+  warn(...args) {
+    if (logLevel > 1) {
+      console.warn(...args);
+    }
+  },
+
+  error(...args) {
+    if (logLevel > 0) {
+      console.error(...args);
+    }
+  },
+};

--- a/app/util/lumber/index.js
+++ b/app/util/lumber/index.js
@@ -1,5 +1,6 @@
 import { curry, flip, has, prop, union, zipWith } from 'ramda';
 import ValueGrammar from './value.pegjs';
+import logger from '../logger';
 
 export class Struct {
   constructor(name, contents = undefined) {
@@ -50,7 +51,7 @@ export const parse = (string) => {
   try {
     return new Value(string);
   } catch (error) {
-    console.error(error);
+    logger.error(error);
     return null;
   }
 };

--- a/app/view/Cover.svelte
+++ b/app/view/Cover.svelte
@@ -11,6 +11,7 @@ import Lobby from './Lobby.svelte';
 import Flow, { Abort } from './component/Flow.svelte';
 import { toast } from './component/Toast.svelte';
 import value from '../util/event';
+import logger from '../util/logger';
 
 const { state, socket } = context();
 
@@ -31,7 +32,7 @@ async function * chooseGame() {
     if (error instanceof Abort) {
       yield * cover();
     } else {
-      console.error(error);
+      logger.error(error);
     }
   }
 }
@@ -52,7 +53,7 @@ async function * createGame() {
     if (error instanceof Abort) {
       yield * chooseGame();
     } else {
-      console.error(error);
+      logger.error(error);
     }
   }
 }
@@ -73,7 +74,7 @@ async function * joinGame() {
     if (error instanceof Abort) {
       yield * chooseGame();
     } else {
-      console.error(error);
+      logger.error(error);
     }
   }
 }
@@ -88,7 +89,7 @@ async function * gameLobby() {
       $state = null;
       yield * chooseGame();
     } else {
-      console.error(error);
+      logger.error(error);
     }
   }
 }

--- a/app/view/component/Toast.svelte
+++ b/app/view/component/Toast.svelte
@@ -1,5 +1,5 @@
 <script context='module'>
-  import { writable, get } from 'svelte/store';
+  import { get, writable } from 'svelte/store';
 
   const toasts = writable([]);
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,10 +19,6 @@ module.exports = {
     'svelte3',
     'ramda',
   ],
-  ignorePatterns: [
-    '**/*.ftl',
-    '*.config.js',
-  ],
   overrides: [
     {
       files: ['*.svelte'],
@@ -38,27 +34,27 @@ module.exports = {
   rules: {
     'arrow-parens': [1, 'always'],
     'brace-style': ['error', '1tbs', {
-      'allowSingleLine': true
+      'allowSingleLine': true,
     }],
     'comma-dangle': ['error', {
       'arrays': 'always-multiline',
       'objects': 'always-multiline',
       'imports': 'always-multiline',
       'exports': 'always-multiline',
-      'functions': 'always-multiline'
+      'functions': 'always-multiline',
     }],
     'curly': 'error',
     'eol-last': ['error', 'always'],
     'indent': ['error', 2, {
-      'SwitchCase': 1
+      'SwitchCase': 1,
     }],
     'newline-before-return': 'off',
-    'no-console': 'off',
+    'no-console': 'error',
     'no-constant-condition': 'off',
     'no-multiple-empty-lines': ['error', {
       'max': 1,
       'maxBOF': 0,
-      'maxEOF': 0
+      'maxEOF': 0,
     }],
     'no-prototype-builtins': 'off',
     'no-unused-vars': 'error',
@@ -68,7 +64,7 @@ module.exports = {
     'space-before-function-paren': ['error', {
       'anonymous': 'always',
       'named': 'never',
-      'asyncArrow': 'always'
+      'asyncArrow': 'always',
     }],
     'no-inner-declarations': 'off',
     'ramda/cond-simplification': 'off', // I don't agree, sometimes cond is more meaningfully correct?

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "dev": "rollup -cw",
     "build": "rollup -c",
-    "lint": "eslint .",
-    "stylelint": "stylelint 'app/**/*.{svelte,css}'"
+    "lint": "eslint app/ -c eslint.config.js",
+    "stylelint": "stylelint 'app/**/*.{svelte,css}'",
+    "server": "cargo run"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I think we don't need some 3rd-party logger, but if we will [loglevel](https://github.com/pimterry/loglevel) is pretty good, and I will implement it (closes #12 )

Also, I configured eslint configs a bit, so now eslintrc is good working proxy of main config. Are we now going to use linters separately from rollup?

Btw, which IDE/editor do you use? I always have svelte/es2020 syntax errors in both WebStorm and VSCode. For example, I don't see the way to suppress syntax errors of postcss-nesting, because it's not the preprocessor or something