### PR TITLE
add marquise start building select action

### DIFF
--- a/app/view/Position.svelte
+++ b/app/view/Position.svelte
@@ -99,3 +99,7 @@
 <Action action='place_token[T, {position.id}]' let:perform let:binding>
   <ClearingPrompt on:click={perform} tooltip={l`tooltip-place`({ piece: binding.T.name })} {x} {y} />
 </Action>
+
+<Action action='place_building[T, {position.id}]' let:perform let:binding>
+  <ClearingPrompt on:click={perform} tooltip={l`tooltip-place`({ piece: binding.T.name })} {x} {y} />
+</Action>

--- a/game/game/buildings.lumber
+++ b/game/game/buildings.lumber
@@ -1,6 +1,6 @@
 :- use(@core).
 :- use(@core::list).
-:- use(^::gameMap(clearing/4, ruin/2)).
+:- use(^::gameMap(clearing/4, itemInRuin/3)).
 
 :- pub(placeBuilding/4).
 placeBuilding(
@@ -92,7 +92,8 @@ buildingSuit(game { buildings: Buildings, .. }, Id, S) :-
 slotAvailable(G, P) :-
     clearing(G, P, _, Slots),
     length([_ : building(G, _, _, P)], Buildings),
-    (itemInRuin(G, P, _) ->> Buildings + 1 < Slots; Buildings < Slots).
+    (itemInRuin(G, P, _) ->> add(Buildings, 1, TakenSlots); TakenSlots =:= Buildings),
+    TakenSlots < Slots.
 
 :- test(
     slotAvailable(

--- a/game/game/buildings.lumber
+++ b/game/game/buildings.lumber
@@ -1,6 +1,7 @@
 :- use(@core).
 :- use(@core::list).
 :- use(^::gameMap(clearing/4)).
+:- use(^::gameMap(ruin/2)).
 
 :- pub(placeBuilding/4).
 placeBuilding(
@@ -90,9 +91,10 @@ buildingSuit(game { buildings: Buildings, .. }, Id, S) :-
 
 :- pub(slotAvailable/2).
 slotAvailable(G, P) :-
-    clearing(G, P, _, S),
-    length([_ : building(G, _, _, P)], L),
-    L < S.
+    clearing(G, P, _, Slots),
+    length([_ : building(G, _, _, P)], Buildings),
+    // TODO: also check ruins
+    Buildings < Slots.
 
 :- test(
     slotAvailable(

--- a/game/game/buildings.lumber
+++ b/game/game/buildings.lumber
@@ -1,7 +1,6 @@
 :- use(@core).
 :- use(@core::list).
-:- use(^::gameMap(clearing/4)).
-:- use(^::gameMap(ruin/2)).
+:- use(^::gameMap(clearing/4, ruin/2)).
 
 :- pub(placeBuilding/4).
 placeBuilding(
@@ -93,8 +92,7 @@ buildingSuit(game { buildings: Buildings, .. }, Id, S) :-
 slotAvailable(G, P) :-
     clearing(G, P, _, Slots),
     length([_ : building(G, _, _, P)], Buildings),
-    // TODO: also check ruins
-    Buildings < Slots.
+    (itemInRuin(G, P, _) ->> Buildings + 1 < Slots; Buildings < Slots).
 
 :- test(
     slotAvailable(

--- a/game/game/gameMap.lumber
+++ b/game/game/gameMap.lumber
@@ -29,7 +29,7 @@ clearing(game { clearings: Clearings, .. }, Id, Suit, Slots) :-
 forest(game { forests: Forests }, Id) :- in(forest { position: Id }, Forests).
 
 :- pub(itemInRuin/3).
-itemInRuin(game { ruin_items: RuinItems, owned_items: OwnedItems, .. }, Clearing, Item) :- 
+itemInRuin(game { ruin_items: RuinItems, owned_items: OwnedItems, .. }, Clearing, Item) :-
   in(ruin_item { clearing: Clearing, item: Item }, RuinItems),
   notin(owned_item { item: Item, .. }, OwnedItems).
 

--- a/game/game/gameMap.lumber
+++ b/game/game/gameMap.lumber
@@ -28,8 +28,10 @@ clearing(game { clearings: Clearings, .. }, Id, Suit, Slots) :-
 :- pub(forest/2).
 forest(game { forests: Forests }, Id) :- in(forest { position: Id }, Forests).
 
-:- pub(ruin/2).
-ruin(game { ruin_items: RuinItems }, Id) :- in(ruin_item { clearing: Id }, RuinItems).
+:- pub(itemInRuin/3).
+itemInRuin(game { ruin_items: RuinItems, owned_items: OwnedItems, .. }, Clearing, Item) :- 
+  in(ruin_item { clearing: Clearing, item: Item }, RuinItems),
+  notin(owned_item { item: Item, .. }, OwnedItems).
 
 :- pub(oppositeCorner/2).
 oppositeCorner(1, 3).

--- a/game/game/gameMap.lumber
+++ b/game/game/gameMap.lumber
@@ -28,6 +28,9 @@ clearing(game { clearings: Clearings, .. }, Id, Suit, Slots) :-
 :- pub(forest/2).
 forest(game { forests: Forests }, Id) :- in(forest { position: Id }, Forests).
 
+:- pub(ruin/2).
+ruin(game { ruin_items: RuinItems }, Id) :- in(ruin_item { clearing: Id }, RuinItems).
+
 :- pub(oppositeCorner/2).
 oppositeCorner(1, 3).
 oppositeCorner(2, 4).

--- a/game/setup/marquise.lumber
+++ b/game/setup/marquise.lumber
@@ -29,7 +29,10 @@ zipPlaceWarriors(State, [W, ..Ws], [C, ..Cs], NewState) :-
     placeWarrior(State, W, C, State2),
     zipPlaceWarriors(State2, Ws, Cs, NewState).
 
-nearKeep(S, P) :- token(S, _, keep, L), (clearing(S, P, _, _), adjacent(S, L, P); P =:= L).
+nearKeep(State, Position) :-
+  token(State, _, keep, KeepPosition),
+  clearing(State, Position, _, _),
+  (adjacent(State, KeepPosition, Position); Position =:= KeepPosition).
 
 actions(_, State, place_building[sawmill, Position]) :- action(State, 1), nearKeep(State, Position), slotAvailable(State, Position).
 actions(_, State, place_building[workshop, Position]) :- action(State, 2), nearKeep(State, Position), slotAvailable(State, Position).


### PR DESCRIPTION
Maybe this PR is kinda WIP, I'm not sure.

I tried to add ruin check to `slotAvailable` predicate, but it didn't work.
```
slotAvailable(G, P) :-
    clearing(G, P, _, Slots),
    length([_ : building(G, _, _, P)], Buildings),
    length([_ : ruin(G, P)], Ruins),
    (Ruins + Buildings) < Slots.
```

I think it's because `ruin(G, P)` doesn't generate array, since it's just boolean. And I don't know how to make increment counter if ruin exist. The code above just changed nothing 🤔 